### PR TITLE
feat: tests for sign_blinded_message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ prost = "0.13.5"
 dirs = "6.0.0"
 sha2 = "0.10"
 rustainers = "0.15.1"
+assert_matches = "1.5.0"
 
 # Local crates
 nuts = { path = "crates/nuts" }

--- a/crates/bin/signer/src/lib.rs
+++ b/crates/bin/signer/src/lib.rs
@@ -1,5 +1,7 @@
 mod methods;
 pub use methods::Method;
+mod server_errors;
+pub use server_errors::Error;
 
 pub use proto::bdhke::{BlindSignature, BlindedMessage, Proof};
 pub use proto::signer::signer_client::SignerClient;

--- a/crates/bin/signer/src/server_errors.rs
+++ b/crates/bin/signer/src/server_errors.rs
@@ -25,21 +25,22 @@ impl<'a> From<Error<'a>> for Status {
         match err {
             Error::CouldNotSignMessage(idx, message, error) => Status::with_error_details(
                 Code::InvalidArgument,
-                format!("failed to sign message {}: {}", message, error),
+                "failed to sign message",
                 ErrorDetails::with_bad_request(vec![FieldViolation::new(
                     format!("messages[{}].blinded_secret", idx),
-                    "the resulting key would have been invalid",
+                    format!(
+                        "given message {message} the resulting key would have been invalid: {error}"
+                    ),
                 )]),
             ),
             Error::CouldNotVerifyProof(idx, proof, secret, error) => Status::with_error_details(
                 Code::InvalidArgument,
-                format!(
-                    "failed to verify proof {} on secret {}: {}",
-                    proof, secret, error
-                ),
+                "failed to verify proof",
                 ErrorDetails::with_bad_request(vec![FieldViolation::new(
                     format!("proofs[{}]", idx),
-                    "the resulting key would have been invalid",
+                    format!(
+                        "given proof {proof}, secret {secret} and the service private key the resulting key would have been invalid: {error}",
+                    ),
                 )]),
             ),
             Error::BadKeysetId(field, idx, bad_keyset_id, error) => Status::with_error_details(
@@ -48,28 +49,25 @@ impl<'a> From<Error<'a>> for Status {
                 ErrorDetails::with_bad_request(vec![FieldViolation::new(
                     format!("{}[{}].keyset_id", field, idx),
                     format!(
-                        "the provided keyset id '{:?}' is invalid: {}",
-                        bad_keyset_id, error
+                        "the provided keyset id '{:?}' is invalid: {error}",
+                        bad_keyset_id,
                     ),
                 )]),
             ),
             Error::KeysetNotFound(field, idx, keyset_id) => Status::with_error_details(
                 Code::NotFound,
-                format!("keyset with id {} not found", keyset_id),
+                "keyset not found",
                 ErrorDetails::with_bad_request(vec![FieldViolation::new(
                     format!("{field}[{idx}].keyset_id"),
-                    "the specified keyset id does not exist",
+                    format!("the specified keyset id '{keyset_id}' does not exist"),
                 )]),
             ),
             Error::AmountNotFound(field, idx, keyset_id, amount) => Status::with_error_details(
                 Code::NotFound,
-                format!(
-                    "amount {} not found in keyset with id {}",
-                    amount, keyset_id
-                ),
+                "amount not found",
                 ErrorDetails::with_bad_request(vec![FieldViolation::new(
                     format!("{field}[{idx}].amount"),
-                    "the specified amount does not exist in the keyset",
+                    format!("amount {amount} does not exist in the keyset with id {keyset_id}"),
                 )]),
             ),
             Error::UnknownUnit(unit) => Status::with_error_details(

--- a/crates/tests/signer-tests/Cargo.toml
+++ b/crates/tests/signer-tests/Cargo.toml
@@ -12,17 +12,17 @@ tonic-health = { workspace = true }
 nuts = { workspace = true }
 dotenvy = { workspace = true }
 bitcoin = { workspace = true }
+assert_matches = { workspace = true }
 
 [[test]]
 name = "declare_keyset"
 path = "declare_keyset.rs"
-
-
 [[test]]
 name = "health_check"
 path = "health_check.rs"
-
-
 [[test]]
 name = "get_root_pubkey"
 path = "get_root_pubkey.rs"
+[[test]]
+name = "sign_blinded_message"
+path = "sign_blinded_message.rs"

--- a/crates/tests/signer-tests/sign_blinded_message.rs
+++ b/crates/tests/signer-tests/sign_blinded_message.rs
@@ -148,7 +148,6 @@ async fn non_existent_keysetid() -> Result<()> {
             max_order: 32,
         })
         .await?;
-
     let declare_keyset_response: DeclareKeysetResponse = res.into_inner();
 
     let keyset_id = KeysetId::from_iter(
@@ -205,7 +204,6 @@ async fn bad_version_keysetid() -> Result<()> {
             max_order: 32,
         })
         .await?;
-
     let declare_keyset_response: DeclareKeysetResponse = res.into_inner();
 
     let keyset_id = KeysetId::from_iter(

--- a/crates/tests/signer-tests/sign_blinded_message.rs
+++ b/crates/tests/signer-tests/sign_blinded_message.rs
@@ -1,0 +1,252 @@
+use anyhow::{Ok, Result};
+use assert_matches::assert_matches;
+use nuts::{
+    Amount,
+    dhke::blind_message,
+    nut00::{BlindedMessage, secret::Secret},
+    nut01::PublicKey,
+    nut02::KeysetId,
+};
+use signer::SignBlindedMessagesRequest;
+use signer::{DeclareKeysetRequest, DeclareKeysetResponse};
+use signer_tests::init_signer_client;
+use std::str::FromStr;
+use tonic::Code;
+
+#[tokio::test]
+async fn secret() -> Result<()> {
+    let mut client = init_signer_client().await?;
+
+    let res = client
+        .declare_keyset(DeclareKeysetRequest {
+            unit: "strk".to_string(),
+            index: 1,
+            max_order: 32,
+        })
+        .await?;
+
+    let declare_keyset_response: DeclareKeysetResponse = res.into_inner();
+
+    let keyset_id = KeysetId::from_iter(
+        declare_keyset_response
+            .clone()
+            .keys
+            .into_iter()
+            .map(|k| PublicKey::from_str(&k.pubkey).unwrap()),
+    );
+
+    let secret = Secret::generate();
+    let (blinded_secret, _secret) = blind_message(&secret.to_bytes(), None).unwrap();
+
+    let blinded_message = BlindedMessage {
+        amount: Amount::ONE,
+        keyset_id,
+        blinded_secret,
+    };
+
+    // bad secret
+    let res = client
+        .sign_blinded_messages(SignBlindedMessagesRequest {
+            messages: [blinded_message.clone()]
+                .iter()
+                .map(|bm| signer::BlindedMessage {
+                    amount: bm.amount.into(),
+                    keyset_id: bm.keyset_id.to_bytes().to_vec(),
+                    blinded_secret: Vec::new(),
+                })
+                .collect(),
+        })
+        .await;
+
+    assert_matches!(
+        res,
+        Err(s) if s.code() == Code::InvalidArgument && s.message() == "invalid secret"
+    );
+
+    // empty secret
+    let res = client
+        .sign_blinded_messages(SignBlindedMessagesRequest {
+            messages: [blinded_message]
+                .iter()
+                .map(|bm| signer::BlindedMessage {
+                    amount: bm.amount.into(),
+                    keyset_id: bm.keyset_id.to_bytes().to_vec(),
+                    blinded_secret: "lorem ipsum".as_bytes().to_vec(),
+                })
+                .collect(),
+        })
+        .await;
+
+    assert_matches!(
+        res,
+        Err(s) if s.code() == Code::InvalidArgument && s.message() == "invalid secret"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn amount() -> Result<()> {
+    let mut client = init_signer_client().await?;
+
+    let res = client
+        .declare_keyset(DeclareKeysetRequest {
+            unit: "strk".to_string(),
+            index: 1,
+            max_order: 32,
+        })
+        .await?;
+
+    let declare_keyset_response: DeclareKeysetResponse = res.into_inner();
+
+    let keyset_id = KeysetId::from_iter(
+        declare_keyset_response
+            .clone()
+            .keys
+            .into_iter()
+            .map(|k| PublicKey::from_str(&k.pubkey).unwrap()),
+    );
+
+    let secret = Secret::generate();
+    let (blinded_secret, _secret) = blind_message(&secret.to_bytes(), None).unwrap();
+
+    let blinded_message = BlindedMessage {
+        amount: Amount::ONE,
+        keyset_id,
+        blinded_secret,
+    };
+
+    let res = client
+        .sign_blinded_messages(SignBlindedMessagesRequest {
+            messages: [blinded_message.clone()]
+                .iter()
+                .map(|bm| signer::BlindedMessage {
+                    amount: 13,
+                    keyset_id: bm.keyset_id.to_bytes().to_vec(),
+                    blinded_secret: bm.blinded_secret.to_bytes().to_vec(),
+                })
+                .collect(),
+        })
+        .await;
+
+    assert_matches!(
+        res,
+        Err(s) if s.code() == Code::NotFound && s.message() == "amount not found"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn non_existent_keysetid() -> Result<()> {
+    let mut client = init_signer_client().await?;
+
+    let res = client
+        .declare_keyset(DeclareKeysetRequest {
+            unit: "strk".to_string(),
+            index: 1,
+            max_order: 32,
+        })
+        .await?;
+
+    let declare_keyset_response: DeclareKeysetResponse = res.into_inner();
+
+    let keyset_id = KeysetId::from_iter(
+        declare_keyset_response
+            .clone()
+            .keys
+            .into_iter()
+            .map(|k| PublicKey::from_str(&k.pubkey).unwrap()),
+    );
+
+    let secret = Secret::generate();
+    let (blinded_secret, _secret) = blind_message(&secret.to_bytes(), None).unwrap();
+
+    let blinded_message = BlindedMessage {
+        amount: Amount::ONE,
+        keyset_id,
+        blinded_secret,
+    };
+
+    let res = client
+        .sign_blinded_messages(SignBlindedMessagesRequest {
+            messages: [blinded_message.clone()]
+                .iter()
+                .map(|bm| {
+                    let mut keyset_id = bm.keyset_id.to_bytes().to_vec();
+                    keyset_id[2] = 0x0;
+
+                    signer::BlindedMessage {
+                        amount: bm.amount.into(),
+                        keyset_id,
+                        blinded_secret: bm.blinded_secret.to_bytes().to_vec(),
+                    }
+                })
+                .collect(),
+        })
+        .await;
+
+    assert_matches!(
+        res,
+        Err(s) if s.code() == Code::NotFound && s.message() == "keyset not found"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn bad_version_keysetid() -> Result<()> {
+    let mut client = init_signer_client().await?;
+
+    let res = client
+        .declare_keyset(DeclareKeysetRequest {
+            unit: "strk".to_string(),
+            index: 1,
+            max_order: 32,
+        })
+        .await?;
+
+    let declare_keyset_response: DeclareKeysetResponse = res.into_inner();
+
+    let keyset_id = KeysetId::from_iter(
+        declare_keyset_response
+            .clone()
+            .keys
+            .into_iter()
+            .map(|k| PublicKey::from_str(&k.pubkey).unwrap()),
+    );
+
+    let secret = Secret::generate();
+    let (blinded_secret, _secret) = blind_message(&secret.to_bytes(), None).unwrap();
+
+    let blinded_message = BlindedMessage {
+        amount: Amount::ONE,
+        keyset_id,
+        blinded_secret,
+    };
+
+    let res = client
+        .sign_blinded_messages(SignBlindedMessagesRequest {
+            messages: [blinded_message.clone()]
+                .iter()
+                .map(|bm| {
+                    let mut keyset_id = vec![0xffu8];
+                    keyset_id.extend_from_slice(&bm.keyset_id.id());
+
+                    signer::BlindedMessage {
+                        amount: bm.amount.into(),
+                        keyset_id,
+                        blinded_secret: bm.blinded_secret.to_bytes().to_vec(),
+                    }
+                })
+                .collect(),
+        })
+        .await;
+
+    assert_matches!(
+        res,
+        Err(s) if s.code() == Code::InvalidArgument && s.message() == "invalid keyset id"
+    );
+
+    Ok(())
+}

--- a/crates/tests/signer-tests/src/lib.rs
+++ b/crates/tests/signer-tests/src/lib.rs
@@ -11,7 +11,7 @@ fn ensure_env_variables() -> Result<()> {
     }
 
     dotenvy::from_filename("signer.env")
-        .map(|_| ()) 
+        .map(|_| ())
         .map_err(|e| {
             anyhow!(
                 "Environment variables not set and failed to load signer.env: {}",


### PR DESCRIPTION
Closes #32 

Tests for `sign_blinded_message`:
- [x] ok
- [x] invalid keysetID(bad version)
- [x] non-existent keysetID
- [x] amount not present
- [x] invalid secret
- [ ] empty message vec