### PR TITLE
Cap the maximum length of inputs and outputs

### DIFF
--- a/crates/bin/node/src/grpc_service.rs
+++ b/crates/bin/node/src/grpc_service.rs
@@ -278,13 +278,6 @@ impl Node for GrpcState {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut conn = match self.pg_pool.acquire().await {
-            Ok(conn) => conn,
-            Err(e) => return Err(Status::internal(e.to_string())),
-        };
-
-        // Amount validation now happens inside the process_swap_inputs and check_outputs_allow_multiple_units functions
-
         let promises = self.inner_swap(&inputs, &outputs).await?;
 
         Ok(Response::new(SwapResponse {
@@ -352,13 +345,6 @@ impl Node for GrpcState {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut conn = match self.pg_pool.acquire().await {
-            Ok(conn) => conn,
-            Err(e) => return Err(Status::internal(e.to_string())),
-        };
-
-        // Amount validation now happens inside the check_outputs_allow_multiple_units function
-
         let promises = self.inner_mint(method, quote_id, &outputs).await?;
 
         Ok(Response::new(MintResponse {
@@ -408,12 +394,6 @@ impl Node for GrpcState {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut conn = match self.pg_pool.acquire().await {
-            Ok(conn) => conn,
-            Err(e) => return Err(Status::internal(e.to_string())),
-        };
-
-        // Amount validation now happens inside the process_melt_inputs function
 
         let response = self
             .inner_melt(method, unit, melt_payment_request, &inputs)

--- a/crates/bin/node/src/grpc_service.rs
+++ b/crates/bin/node/src/grpc_service.rs
@@ -394,7 +394,6 @@ impl Node for GrpcState {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-
         let response = self
             .inner_melt(method, unit, melt_payment_request, &inputs)
             .await?;

--- a/crates/bin/node/src/grpc_service.rs
+++ b/crates/bin/node/src/grpc_service.rs
@@ -233,10 +233,14 @@ impl Node for GrpcState {
         let swap_request = swap_request.into_inner();
 
         if swap_request.inputs.len() > 64 {
-            return Err(Status::invalid_argument("Too many inputs: maximum allowed is 64"));
+            return Err(Status::invalid_argument(
+                "Too many inputs: maximum allowed is 64",
+            ));
         }
         if swap_request.outputs.len() > 64 {
-            return Err(Status::invalid_argument("Too many outputs: maximum allowed is 64"));
+            return Err(Status::invalid_argument(
+                "Too many outputs: maximum allowed is 64",
+            ));
         }
 
         if swap_request.inputs.is_empty() {
@@ -323,7 +327,9 @@ impl Node for GrpcState {
         let mint_request = mint_request.into_inner();
 
         if mint_request.outputs.len() > 64 {
-            return Err(Status::invalid_argument("Too many outputs: maximum allowed is 64"));
+            return Err(Status::invalid_argument(
+                "Too many outputs: maximum allowed is 64",
+            ));
         }
 
         if mint_request.outputs.is_empty() {
@@ -374,7 +380,9 @@ impl Node for GrpcState {
         let melt_request = melt_request.into_inner();
 
         if melt_request.inputs.len() > 64 {
-            return Err(Status::invalid_argument("Too many inputs: maximum allowed is 64"));
+            return Err(Status::invalid_argument(
+                "Too many inputs: maximum allowed is 64",
+            ));
         }
 
         if melt_request.inputs.is_empty() {

--- a/crates/bin/node/src/keyset_cache.rs
+++ b/crates/bin/node/src/keyset_cache.rs
@@ -41,15 +41,15 @@ impl CachedKeysetInfo {
             max_order,
         }
     }
-    
+
     pub fn active(&self) -> bool {
         self.active
     }
-    
+
     pub fn unit(&self) -> Unit {
         self.unit
     }
-    
+
     pub fn max_order(&self) -> u32 {
         self.max_order
     }
@@ -158,7 +158,7 @@ impl KeysetCache {
             unit: db_content.unit(),
             max_order: db_content.max_order().into(),
         };
-        
+
         {
             let mut cache_write_lock = self.infos.write().await;
             cache_write_lock.insert(keyset_id, info.clone());

--- a/crates/bin/node/src/keyset_cache.rs
+++ b/crates/bin/node/src/keyset_cache.rs
@@ -41,6 +41,18 @@ impl CachedKeysetInfo {
             max_order,
         }
     }
+    
+    pub fn active(&self) -> bool {
+        self.active
+    }
+    
+    pub fn unit(&self) -> Unit {
+        self.unit
+    }
+    
+    pub fn max_order(&self) -> u32 {
+        self.max_order
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -126,12 +138,12 @@ impl KeysetCache {
         &self,
         conn: &mut PgConnection,
         keyset_id: KeysetId,
-    ) -> Result<(bool, Unit, u32), Error> {
+    ) -> Result<CachedKeysetInfo, Error> {
         // happy path: the infos are already in the cache
         {
             let cache_read_lock = self.infos.read().await;
             if let Some(info) = cache_read_lock.get(&keyset_id) {
-                return Ok((info.active, info.unit, info.max_order));
+                return Ok(info.clone());
             }
         }
 
@@ -141,22 +153,17 @@ impl KeysetCache {
             .map_err(|e| Error::UnknownKeysetId(keyset_id, e))?;
 
         // Save the infos in the cache
+        let info = CachedKeysetInfo {
+            active: db_content.active(),
+            unit: db_content.unit(),
+            max_order: db_content.max_order().into(),
+        };
+        
         {
             let mut cache_write_lock = self.infos.write().await;
-            cache_write_lock.insert(
-                keyset_id,
-                CachedKeysetInfo {
-                    active: db_content.active(),
-                    unit: db_content.unit(),
-                    max_order: db_content.max_order().into(),
-                },
-            );
+            cache_write_lock.insert(keyset_id, info.clone());
         }
 
-        Ok((
-            db_content.active(),
-            db_content.unit(),
-            db_content.max_order().into(),
-        ))
+        Ok(info)
     }
 }

--- a/crates/bin/node/src/keyset_cache.rs
+++ b/crates/bin/node/src/keyset_cache.rs
@@ -35,7 +35,11 @@ pub struct CachedKeysetInfo {
 
 impl CachedKeysetInfo {
     pub fn new(active: bool, unit: Unit, max_order: u32) -> Self {
-        Self { active, unit, max_order }
+        Self {
+            active,
+            unit,
+            max_order,
+        }
     }
 }
 
@@ -149,6 +153,10 @@ impl KeysetCache {
             );
         }
 
-        Ok((db_content.active(), db_content.unit(), db_content.max_order().into()))
+        Ok((
+            db_content.active(),
+            db_content.unit(),
+            db_content.max_order().into(),
+        ))
     }
 }

--- a/crates/bin/node/src/keyset_rotation.rs
+++ b/crates/bin/node/src/keyset_rotation.rs
@@ -54,7 +54,7 @@ impl KeysetRotationService for GrpcState {
             insert_keysets_query_builder.add_row(new_keyset_id, &unit, max_order, index);
 
             self.keyset_cache
-                .insert_info(new_keyset_id, CachedKeysetInfo::new(true, unit))
+                .insert_info(new_keyset_id, CachedKeysetInfo::new(true, unit, max_order))
                 .await;
 
             let keys = response

--- a/crates/bin/node/src/logic/inputs.rs
+++ b/crates/bin/node/src/logic/inputs.rs
@@ -155,7 +155,7 @@ pub async fn process_swap_inputs<'a>(
 
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.max_order();
-        let max_value = (1u64 << max_order) - 1;
+        let max_value = 1u64 << (max_order - 1);
 
         if u64::from(proof.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(

--- a/crates/bin/node/src/logic/inputs.rs
+++ b/crates/bin/node/src/logic/inputs.rs
@@ -86,11 +86,7 @@ pub async fn process_melt_inputs<'a>(
 
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.max_order();
-        let max_value = if max_order >= 64 {
-            u64::MAX
-        } else {
-            (1u64 << max_order) - 1
-        };
+        let max_value = (1u64 << max_order) - 1;
 
         if u64::from(proof.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(
@@ -159,11 +155,7 @@ pub async fn process_swap_inputs<'a>(
         
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.max_order();
-        let max_value = if max_order >= 64 {
-            u64::MAX
-        } else {
-            (1u64 << max_order) - 1
-        };
+        let max_value = (1u64 << max_order) - 1;
 
         if u64::from(proof.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(

--- a/crates/bin/node/src/logic/inputs.rs
+++ b/crates/bin/node/src/logic/inputs.rs
@@ -37,7 +37,7 @@ pub enum Error {
     Invalid,
     #[error("Proof already used")]
     Used,
-    #[error("amount exceeds max order for keyset {0}: amount {1} exceeds max value {2}")]
+    #[error("amount {1} exceeds max order {2} of keyset {0}")]
     AmountExceedsMaxOrder(KeysetId, Amount, u64),
 }
 
@@ -152,7 +152,7 @@ pub async fn process_swap_inputs<'a>(
         let keyset_info = keyset_cache.get_keyset_info(conn, proof.keyset_id).await?;
 
         let keyset_unit = keyset_info.unit();
-        
+
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.max_order();
         let max_value = (1u64 << max_order) - 1;

--- a/crates/bin/node/src/logic/inputs.rs
+++ b/crates/bin/node/src/logic/inputs.rs
@@ -85,7 +85,7 @@ pub async fn process_melt_inputs<'a>(
             .map_err(Error::KeysetCache)?;
 
         // Validate amount doesn't exceed max_order
-        let max_order = keyset_info.2;
+        let max_order = keyset_info.max_order();
         let max_value = if max_order >= 64 {
             u64::MAX
         } else {
@@ -101,7 +101,7 @@ pub async fn process_melt_inputs<'a>(
         }
 
         // Check all units are the same
-        let unit = keyset_info.1;
+        let unit = keyset_info.unit();
         match common_unit {
             Some(u) => {
                 if u != unit {
@@ -155,10 +155,10 @@ pub async fn process_swap_inputs<'a>(
 
         let keyset_info = keyset_cache.get_keyset_info(conn, proof.keyset_id).await?;
 
-        let keyset_unit = keyset_info.1;
-
+        let keyset_unit = keyset_info.unit();
+        
         // Validate amount doesn't exceed max_order
-        let max_order = keyset_info.2;
+        let max_order = keyset_info.max_order();
         let max_value = if max_order >= 64 {
             u64::MAX
         } else {

--- a/crates/bin/node/src/logic/inputs.rs
+++ b/crates/bin/node/src/logic/inputs.rs
@@ -91,12 +91,12 @@ pub async fn process_melt_inputs<'a>(
         } else {
             (1u64 << max_order) - 1
         };
-        
+
         if u64::from(proof.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(
                 proof.keyset_id,
                 proof.amount,
-                max_value
+                max_value,
             ));
         }
 
@@ -156,7 +156,7 @@ pub async fn process_swap_inputs<'a>(
         let keyset_info = keyset_cache.get_keyset_info(conn, proof.keyset_id).await?;
 
         let keyset_unit = keyset_info.1;
-    
+
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.2;
         let max_value = if max_order >= 64 {
@@ -164,15 +164,15 @@ pub async fn process_swap_inputs<'a>(
         } else {
             (1u64 << max_order) - 1
         };
-        
+
         if u64::from(proof.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(
                 proof.keyset_id,
                 proof.amount,
-                max_value
+                max_value,
             ));
         }
-        
+
         match amounts_per_unit.iter_mut().find(|(u, _)| *u == keyset_unit) {
             Some((_, a)) => {
                 *a = a

--- a/crates/bin/node/src/logic/inputs.rs
+++ b/crates/bin/node/src/logic/inputs.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use tonic::Status;
 
 use db_node::InsertSpentProofsQueryBuilder;
-use nuts::{Amount, nut00::Proof, nut01::PublicKey};
+use nuts::{Amount, nut00::Proof, nut01::PublicKey, nut02::KeysetId};
 use signer::VerifyProofsRequest;
 use sqlx::PgConnection;
 
@@ -37,6 +37,8 @@ pub enum Error {
     Invalid,
     #[error("Proof already used")]
     Used,
+    #[error("amount exceeds max order for keyset {0}: amount {1} exceeds max value {2}")]
+    AmountExceedsMaxOrder(KeysetId, Amount, u64),
 }
 
 impl From<Error> for Status {
@@ -48,7 +50,8 @@ impl From<Error> for Status {
             | Error::TotalAmountTooBig
             | Error::TotalFeeTooBig
             | Error::Invalid
-            | Error::Used => Status::invalid_argument(value.to_string()),
+            | Error::Used
+            | Error::AmountExceedsMaxOrder(_, _, _) => Status::invalid_argument(value.to_string()),
             Error::Db(sqlx::Error::RowNotFound) => Status::not_found(value.to_string()),
             Error::Db(_) | Error::KeysetCache(_) => Status::internal(value.to_string()),
             Error::Signer(status) => status,
@@ -80,6 +83,22 @@ pub async fn process_melt_inputs<'a>(
             .get_keyset_info(conn, proof.keyset_id)
             .await
             .map_err(Error::KeysetCache)?;
+
+        // Validate amount doesn't exceed max_order
+        let max_order = keyset_info.2;
+        let max_value = if max_order >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << max_order) - 1
+        };
+        
+        if u64::from(proof.amount) > max_value {
+            return Err(Error::AmountExceedsMaxOrder(
+                proof.keyset_id,
+                proof.amount,
+                max_value
+            ));
+        }
 
         // Check all units are the same
         let unit = keyset_info.1;
@@ -137,6 +156,23 @@ pub async fn process_swap_inputs<'a>(
         let keyset_info = keyset_cache.get_keyset_info(conn, proof.keyset_id).await?;
 
         let keyset_unit = keyset_info.1;
+    
+        // Validate amount doesn't exceed max_order
+        let max_order = keyset_info.2;
+        let max_value = if max_order >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << max_order) - 1
+        };
+        
+        if u64::from(proof.amount) > max_value {
+            return Err(Error::AmountExceedsMaxOrder(
+                proof.keyset_id,
+                proof.amount,
+                max_value
+            ));
+        }
+        
         match amounts_per_unit.iter_mut().find(|(u, _)| *u == keyset_unit) {
             Some((_, a)) => {
                 *a = a

--- a/crates/bin/node/src/logic/outputs.rs
+++ b/crates/bin/node/src/logic/outputs.rs
@@ -109,7 +109,7 @@ pub async fn check_outputs_allow_multiple_units(
 
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.max_order();
-        let max_value = (1u64 << max_order) - 1;
+        let max_value = 1u64 << (max_order - 1);
 
         if u64::from(blind_message.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(

--- a/crates/bin/node/src/logic/outputs.rs
+++ b/crates/bin/node/src/logic/outputs.rs
@@ -60,11 +60,11 @@ pub async fn check_outputs_allow_single_unit(
             .await?;
 
         // We only sign with active keysets
-        if !keyset_info.0 {
+        if !keyset_info.active() {
             return Err(Error::InactiveKeyset(blind_message.keyset_id));
         }
 
-        match (unit, keyset_info.1) {
+        match (unit, keyset_info.unit()) {
             (None, u) => unit = Some(u),
             (Some(unit), u) if u != unit => return Err(Error::MultipleUnits),
             _ => {}
@@ -103,12 +103,12 @@ pub async fn check_outputs_allow_multiple_units(
             .await?;
 
         // We only sign with active keysets
-        if !keyset_info.0 {
+        if !keyset_info.active() {
             return Err(Error::InactiveKeyset(blind_message.keyset_id));
         }
 
         // Validate amount doesn't exceed max_order
-        let max_order = keyset_info.2;
+        let max_order = keyset_info.max_order();
         let max_value = if max_order >= 64 {
             u64::MAX
         } else {
@@ -124,7 +124,7 @@ pub async fn check_outputs_allow_multiple_units(
         }
 
         // Incement total amount
-        let keyset_unit = keyset_info.1;
+        let keyset_unit = keyset_info.unit();
         match total_amounts.iter_mut().find(|(u, _)| *u == keyset_unit) {
             Some((_, a)) => {
                 *a = a

--- a/crates/bin/node/src/logic/outputs.rs
+++ b/crates/bin/node/src/logic/outputs.rs
@@ -98,7 +98,9 @@ pub async fn check_outputs_allow_multiple_units(
             return Err(Error::DuplicateOutput);
         }
 
-        let keyset_info = keyset_cache.get_keyset_info(conn, blind_message.keyset_id).await?;
+        let keyset_info = keyset_cache
+            .get_keyset_info(conn, blind_message.keyset_id)
+            .await?;
 
         // We only sign with active keysets
         if !keyset_info.0 {
@@ -112,12 +114,12 @@ pub async fn check_outputs_allow_multiple_units(
         } else {
             (1u64 << max_order) - 1
         };
-        
+
         if u64::from(blind_message.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(
                 blind_message.keyset_id,
                 blind_message.amount,
-                max_value
+                max_value,
             ));
         }
 

--- a/crates/bin/node/src/logic/outputs.rs
+++ b/crates/bin/node/src/logic/outputs.rs
@@ -110,12 +110,12 @@ pub async fn check_outputs_allow_multiple_units(
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.max_order();
         let max_value = (1u64 << max_order) - 1;
-        
+
         if u64::from(blind_message.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(
                 blind_message.keyset_id,
                 blind_message.amount,
-                max_value
+                max_value,
             ));
         }
 

--- a/crates/bin/node/src/logic/outputs.rs
+++ b/crates/bin/node/src/logic/outputs.rs
@@ -109,17 +109,13 @@ pub async fn check_outputs_allow_multiple_units(
 
         // Validate amount doesn't exceed max_order
         let max_order = keyset_info.max_order();
-        let max_value = if max_order >= 64 {
-            u64::MAX
-        } else {
-            (1u64 << max_order) - 1
-        };
-
+        let max_value = (1u64 << max_order) - 1;
+        
         if u64::from(blind_message.amount) > max_value {
             return Err(Error::AmountExceedsMaxOrder(
                 blind_message.keyset_id,
                 blind_message.amount,
-                max_value,
+                max_value
             ));
         }
 

--- a/crates/bin/node/src/routes/mint.rs
+++ b/crates/bin/node/src/routes/mint.rs
@@ -47,7 +47,9 @@ impl From<Error> for Status {
                 | OutputsError::MultipleUnits
                 | OutputsError::TotalAmountTooBig
                 | OutputsError::AlreadySigned
-                | OutputsError::AmountExceedsMaxOrder(_, _, _) => Status::invalid_argument(error.to_string()),
+                | OutputsError::AmountExceedsMaxOrder(_, _, _) => {
+                    Status::invalid_argument(error.to_string())
+                }
                 OutputsError::Db(sqlx::Error::RowNotFound) => Status::not_found(error.to_string()),
                 OutputsError::Db(_) | OutputsError::KeysetCache(_) => {
                     Status::internal(error.to_string())

--- a/crates/bin/node/src/routes/mint.rs
+++ b/crates/bin/node/src/routes/mint.rs
@@ -46,7 +46,8 @@ impl From<Error> for Status {
                 | OutputsError::InactiveKeyset(_)
                 | OutputsError::MultipleUnits
                 | OutputsError::TotalAmountTooBig
-                | OutputsError::AlreadySigned => Status::invalid_argument(error.to_string()),
+                | OutputsError::AlreadySigned
+                | OutputsError::AmountExceedsMaxOrder(_, _, _) => Status::invalid_argument(error.to_string()),
                 OutputsError::Db(sqlx::Error::RowNotFound) => Status::not_found(error.to_string()),
                 OutputsError::Db(_) | OutputsError::KeysetCache(_) => {
                     Status::internal(error.to_string())

--- a/crates/bin/node/src/routes/swap.rs
+++ b/crates/bin/node/src/routes/swap.rs
@@ -49,7 +49,9 @@ impl From<Error> for Status {
                 | OutputsError::MultipleUnits
                 | OutputsError::TotalAmountTooBig
                 | OutputsError::AlreadySigned
-                | OutputsError::AmountExceedsMaxOrder(_, _, _) => Status::invalid_argument(error.to_string()),
+                | OutputsError::AmountExceedsMaxOrder(_, _, _) => {
+                    Status::invalid_argument(error.to_string())
+                }
                 OutputsError::Db(sqlx::Error::RowNotFound) => Status::not_found(error.to_string()),
                 OutputsError::Db(_) | OutputsError::KeysetCache(_) => {
                     Status::internal(error.to_string())

--- a/crates/bin/node/src/routes/swap.rs
+++ b/crates/bin/node/src/routes/swap.rs
@@ -48,7 +48,8 @@ impl From<Error> for Status {
                 | OutputsError::InactiveKeyset(_)
                 | OutputsError::MultipleUnits
                 | OutputsError::TotalAmountTooBig
-                | OutputsError::AlreadySigned => Status::invalid_argument(error.to_string()),
+                | OutputsError::AlreadySigned
+                | OutputsError::AmountExceedsMaxOrder(_, _, _) => Status::invalid_argument(error.to_string()),
                 OutputsError::Db(sqlx::Error::RowNotFound) => Status::not_found(error.to_string()),
                 OutputsError::Db(_) | OutputsError::KeysetCache(_) => {
                     Status::internal(error.to_string())

--- a/crates/tests/signer-tests/declare_keyset.rs
+++ b/crates/tests/signer-tests/declare_keyset.rs
@@ -52,7 +52,6 @@ async fn unknown_unit() -> Result<()> {
     assert!(res.is_err());
     assert!(matches!(res, Err(status) if status.code() == tonic::Code::InvalidArgument ));
 
-
     Ok(())
 }
 

--- a/crates/wallet/src/db/mod.rs
+++ b/crates/wallet/src/db/mod.rs
@@ -124,12 +124,11 @@ pub fn upsert_node_keysets(
     "#;
 
     for keyset in keysets {
-        let id: [u8; 8] = keyset
-            .id
-            .try_into()
-            .map_err(|e: Vec<u8>| rusqlite::Error::ToSqlConversionFailure(
-                format!("Invalid keyset ID length: {}", e.len()).into()
-            ))?;
+        let id: [u8; 8] = keyset.id.try_into().map_err(|e: Vec<u8>| {
+            rusqlite::Error::ToSqlConversionFailure(
+                format!("Invalid keyset ID length: {}", e.len()).into(),
+            )
+        })?;
         conn.execute(
             UPSERT_NODE_KEYSET,
             (id, node_id, keyset.unit, keyset.active),
@@ -143,8 +142,8 @@ pub fn upsert_node_keysets(
     let new_keyset_ids = {
         let mut stmt = conn.prepare(GET_NEW_KEYSETS)?;
         stmt.query_map([], |row| row.get(0))?
-        .map(|res| res)
-        .collect::<Result<Vec<_>>>()?
+            .map(|res| res)
+            .collect::<Result<Vec<_>>>()?
     };
 
     conn.execute("DELETE FROM _tmp_inserted", [])?;


### PR DESCRIPTION
## PR Description 
Input Validation for Mint, Swap, and Melt
This PR introduces early validation checks in the node to ensure input and output vectors for mint, swap, and melt operations adhere to security constraints and prevent potential DDoS attacks.

## Changes & Enhancements:
✅ Enforce a maximum length of 64 elements for user-provided input/output vectors.
✅ Ensure input/output vectors are not empty to prevent invalid operations.
✅ Validate that all amounts are below max_order, retrieved from the keyset in the database.

By catching these conditions early in the process, we enhance system robustness and mitigate unnecessary processing of invalid transactions

Closes #47 