### PR TITLE
feat: implemented test for fn of `StarknetU256`

### DIFF
--- a/crates/starknet/types/src/u256.rs
+++ b/crates/starknet/types/src/u256.rs
@@ -60,11 +60,17 @@ impl StarknetU256 {
                 (u128::from_be_bytes(low), 0u128)
             }
             l if l < 32 => {
-                let mut low = [0u8; 16];
-                let mut high = [0u8; 16];
-                low.copy_from_slice(&bytes[l - 16..]);
-                high.copy_from_slice(&bytes[0..l - 16]);
-                (u128::from_be_bytes(low), u128::from_be_bytes(high))
+                let mut low_bytes = [0u8; 16];
+                low_bytes.copy_from_slice(&bytes[l - 16..]);
+
+                let mut high_bytes = [0u8; 16];
+                let high_part_len = l - 16;
+                high_bytes[16 - high_part_len..].copy_from_slice(&bytes[..high_part_len]);
+
+                (
+                    u128::from_be_bytes(low_bytes),
+                    u128::from_be_bytes(high_bytes),
+                )
             }
             l => return Err(StarknetU256FromBytesSliceError(l)),
         };
@@ -153,33 +159,194 @@ impl From<&StarknetU256> for primitive_types::U256 {
 
 #[cfg(test)]
 mod tests {
+    use bitcoin_hashes::sha256::Hash as Sha256;
+    use num_bigint::BigUint;
+    use nuts::Amount;
+    use primitive_types::U256;
     use starknet_types_core::felt::Felt;
 
-    use super::StarknetU256;
+    use super::{StarknetU256, StarknetU256FromBytesSliceError};
 
     #[test]
-    fn starknet_and_primitive_types_u256_conversion() {
-        let pt = primitive_types::U256::MAX;
+    fn test_zero() {
+        let zero = StarknetU256::ZERO;
+        assert_eq!(zero.low, Felt::ZERO);
+        assert_eq!(zero.high, Felt::ZERO);
+    }
+
+    #[test]
+    fn test_from_parts() {
+        let value = StarknetU256::from_parts(42u64, 0u64);
+        assert_eq!(value.low, Felt::from(42u128));
+        assert_eq!(value.high, Felt::ZERO);
+
+        let value = StarknetU256::from_parts(u128::MAX, 1u64);
+        assert_eq!(value.low, Felt::from(u128::MAX));
+        assert_eq!(value.high, Felt::from(1u128));
+    }
+
+    #[test]
+    fn test_to_bytes_be() {
+        let value = StarknetU256::from_parts(0x1234567890ABCDEFu64, 0xFEDCBA0987654321u64);
+        let bytes = value.to_bytes_be();
+
+        // Verify the bytes are in big-endian order
+        assert_eq!(
+            bytes[24..],
+            [0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF]
+        );
+        assert_eq!(
+            bytes[8..16],
+            [0xFE, 0xDC, 0xBA, 0x09, 0x87, 0x65, 0x43, 0x21]
+        );
+    }
+
+    #[test]
+    fn test_from_bytes() {
+        let mut bytes = [0u8; 32];
+        bytes[16..24].copy_from_slice(&[0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF]);
+        bytes[0..8].copy_from_slice(&[0xFE, 0xDC, 0xBA, 0x09, 0x87, 0x65, 0x43, 0x21]);
+
+        let value = StarknetU256::from_bytes(&bytes);
+        assert_eq!(
+            value.low,
+            Felt::from(0x1234567890abcdef0000000000000000_u128)
+        );
+        assert_eq!(
+            value.high,
+            Felt::from(0xFEDCBA09876543210000000000000000_u128)
+        );
+    }
+
+    #[test]
+    fn test_from_bytes_slice() {
+        // Test empty slice
+        assert_eq!(
+            StarknetU256::from_bytes_slice(&[]).unwrap(),
+            StarknetU256::ZERO
+        );
+
+        // Test 16-byte slice
+        let bytes = [
+            0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56, 0x78, 0x90, 0xAB,
+            0xCD, 0xEF,
+        ];
+        let value = StarknetU256::from_bytes_slice(&bytes).unwrap();
+        assert_eq!(value.low, Felt::from(u128::from_be_bytes(bytes)));
+        assert_eq!(value.high, Felt::ZERO);
+
+        // Test 32-byte slice
+        let mut bytes = [0u8; 32];
+        // Low part (last 16 bytes) - only set first 8 bytes
+        bytes[24..].copy_from_slice(&[0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF]);
+        // High part (first 16 bytes) - set first 8 bytes, pad with zeros
+        bytes[8..16].copy_from_slice(&[0xFE, 0xDC, 0xBA, 0x09, 0x87, 0x65, 0x43, 0x21]);
+        let value = StarknetU256::from_bytes_slice(&bytes).unwrap();
+        assert_eq!(value.low, Felt::from(0x1234567890ABCDEF_u128));
+        assert_eq!(value.high, Felt::from(0xFEDCBA0987654321_u128));
+
+        // Test slice too long
+        let bytes = [0u8; 33];
+        assert!(matches!(
+            StarknetU256::from_bytes_slice(&bytes),
+            Err(StarknetU256FromBytesSliceError(33))
+        ));
+    }
+
+    #[test]
+    fn test_from_sha256() {
+        let data = b"test data";
+        let hash = Sha256::hash(data);
+        let value = StarknetU256::from(hash);
+
+        // Verify the conversion preserves the hash bytes
+        let bytes = value.to_bytes_be();
+        assert_eq!(&bytes, hash.as_byte_array());
+    }
+
+    #[test]
+    fn test_from_amount() {
+        let amount = Amount::from(42u64);
+        let value = StarknetU256::from(amount);
+        assert_eq!(value.low, Felt::from(42u128));
+        assert_eq!(value.high, Felt::ZERO);
+
+        // Test number too big
+        let mut bytes = [0u8; 33];
+        // Set the most significant byte (index 32 for little-endian) to make the number exceed U256::MAX
+        bytes[32] = 1;
+        let biguint = BigUint::from_bytes_le(&bytes);
+        assert!(matches!(
+            StarknetU256::try_from(biguint),
+            Err(super::TryU256FromBigUintError::TooBig)
+        ));
+    }
+
+    #[test]
+    fn test_try_from_biguint() {
+        // Test small number
+        let biguint = BigUint::from(42u64);
+        let value = StarknetU256::try_from(biguint).unwrap();
+        assert_eq!(value.low, Felt::from(42u128));
+        assert_eq!(value.high, Felt::ZERO);
+
+        // Test number that fits in low part
+        let biguint = BigUint::from(u128::MAX);
+        let value = StarknetU256::try_from(biguint).unwrap();
+        assert_eq!(value.low, Felt::from(u128::MAX));
+        assert_eq!(value.high, Felt::ZERO);
+
+        // Test number that needs both parts
+        let biguint = BigUint::from(u128::MAX) + BigUint::from(1u64);
+        let value = StarknetU256::try_from(biguint).unwrap();
+        assert_eq!(value.low, Felt::from(0u128));
+        assert_eq!(value.high, Felt::from(1u128));
+
+        // Test number too big
+        let mut bytes = [0u8; 33];
+        // Set the most significant byte (index 32 for little-endian) to make the number exceed U256::MAX
+        bytes[32] = 1;
+        let biguint = BigUint::from_bytes_le(&bytes);
+        assert!(matches!(
+            StarknetU256::try_from(biguint),
+            Err(super::TryU256FromBigUintError::TooBig)
+        ));
+    }
+
+    #[test]
+    fn test_primitive_types_u256_conversion() {
+        // Test max value
+        let pt = U256::MAX;
         let s = StarknetU256::from(pt);
+        assert_eq!(U256::from(s), pt);
 
-        assert_eq!(primitive_types::U256::from(s), pt);
-
-        let pt = primitive_types::U256::zero();
+        // Test zero
+        let pt = U256::zero();
         let s = StarknetU256::from(pt);
+        assert_eq!(U256::from(s), pt);
 
-        assert_eq!(primitive_types::U256::from(s), pt);
-
-        let pt = primitive_types::U256::one();
+        // Test one
+        let pt = U256::one();
         let s = StarknetU256::from(pt);
+        assert_eq!(U256::from(s), pt);
 
-        assert_eq!(primitive_types::U256::from(s), pt);
-
+        // Test specific values
         let s = StarknetU256 {
             low: Felt::from_hex_unchecked("0xbabe"),
             high: Felt::from_hex_unchecked("0xcafe"),
         };
-        let pt = primitive_types::U256::from(&s);
-
+        let pt = U256::from(&s);
         assert_eq!(StarknetU256::from(pt), s);
+    }
+
+    #[test]
+    fn test_display() {
+        let value = StarknetU256 {
+            low: Felt::from_hex_unchecked("0x1234"),
+            high: Felt::from_hex_unchecked("0x5678"),
+        };
+        let display = format!("{}", value);
+        assert!(display.contains("low: 0x1234"));
+        assert!(display.contains("high: 0x5678"));
     }
 }


### PR DESCRIPTION
This PR introduces unit tests for the StarknetU256 type. 

The tests cover core functionalities such as creation, byte conversions, and conversions from related types (Sha256, Amount, BigUint, primitive_types::U256). 

Edge cases and display formatting are also tested.

Test results
<img width="747" alt="Screenshot 2025-04-12 at 1 51 54 PM" src="https://github.com/user-attachments/assets/f9a8b969-ce08-4f6b-bcd5-60c32a6889c0" />

closes #77 
